### PR TITLE
ci: fix initial workflow runs for empty tests and release-please bootstrap

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/preset-base": "0.0.0",
-  "packages/preset-web": "0.0.0",
-  "packages/preset-cli": "0.0.0"
+  "packages/preset-base": "0.0.1",
+  "packages/preset-web": "0.0.1",
+  "packages/preset-cli": "0.0.1"
 }

--- a/packages/preset-base/package.json
+++ b/packages/preset-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ozzylabs/preset-base",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "OzzyLabs base preset for create-agentic-app: shared linters, formatters, hooks, and editor configuration.",
   "type": "module",
   "main": "./dist/index.mjs",
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/preset-cli/package.json
+++ b/packages/preset-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ozzylabs/preset-cli",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "OzzyLabs Node.js CLI preset for create-agentic-app: tsdown + @clack/prompts + vitest + CLI package.json. Extends @ozzylabs/preset-base.",
   "type": "module",
   "main": "./dist/index.mjs",
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
@@ -48,7 +48,7 @@
     "vitest"
   ],
   "peerDependencies": {
-    "@ozzylabs/preset-base": "^0.0.0"
+    "@ozzylabs/preset-base": "^0.0.1"
   },
   "devDependencies": {
     "@ozzylabs/preset-base": "workspace:*",

--- a/packages/preset-web/package.json
+++ b/packages/preset-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ozzylabs/preset-web",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "OzzyLabs web preset for create-agentic-app: Astro + React + Tailwind + Vite. Extends @ozzylabs/preset-base.",
   "type": "module",
   "main": "./dist/index.mjs",
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
@@ -48,7 +48,7 @@
     "tailwind"
   ],
   "peerDependencies": {
-    "@ozzylabs/preset-base": "^0.0.0"
+    "@ozzylabs/preset-base": "^0.0.1"
   },
   "devDependencies": {
     "@ozzylabs/preset-base": "workspace:*",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,6 @@
       "package-name": "@ozzylabs/preset-base",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
@@ -20,7 +19,6 @@
       "package-name": "@ozzylabs/preset-web",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
@@ -32,7 +30,6 @@
       "package-name": "@ozzylabs/preset-cli",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

initial scaffold (commit `2013e8b`) push 後の最初の workflow runs で発生した 2 つのバグを修正する。

### CI failure: `vitest run` exits with code 1 on empty test dirs

各 preset package には未だテストファイルが存在しない（v0.1.0 実装は #6/#7/#8 で追加予定）。`vitest run` はテスト 0 件で exit 1 を返すため CI が失敗していた。各 package の `test` script に `--passWithNoTests` を追加して、テスト未配置の段階でも CI を通す。

### Release failure: release-please created `1.0.0` PRs and exit 1 on label add

- release-please の node strategy は manifest がデフォルトの `0.0.0` の場合に "no prior release" と判定し、`initialReleaseVersion()`（デフォルト `1.0.0`）にフォールバックしていた。これにより目標の v0.1.0 ではなく 1.0.0 として PR が作成されていた。
- 加えて `bump-patch-for-minor-pre-major: true` が pre-1.0 の `feat` を patch bump にしてしまうため、ADR-0017 が掲げる v0.1.0 ターゲットと噛み合わない。
- repo に `autorelease: tagged` / `triggered` / `snapshot` ラベルが存在しなかったため、release-please action が PR 生成後のラベル付与で exit 1 していた。

### Fix

- `.release-please-manifest.json` と各 `package.json` を `0.0.0` → `0.0.1` に変更（manifest を "既存の prior release" として認識させる）
- `release-please-config.json` から `bump-patch-for-minor-pre-major` を削除（pre-1.0 でも `feat` が minor bump されるように）
- workspace 間の `peerDependencies` を `^0.0.1` に同期
- 不足していた release-please ラベル（`autorelease: tagged` / `triggered` / `snapshot`）を repo に作成
- 1.0.0 で誤って作られた既存 release PR `#1` `#2` `#3` は close 済み（branch 削除）

次回 push 以降、release-please は正しく v0.1.0 の release PR を生成する想定。

## Test plan

- [x] ローカル: `pnpm -r run typecheck` 通過
- [x] ローカル: `pnpm -r run build` 通過
- [x] ローカル: `pnpm -r run test`（`--passWithNoTests` 経由）通過
- [x] ローカル: `pnpm run lint:all` 通過
- [ ] CI: 全 jobs 緑（lint / typecheck / build / test）
- [ ] PR Check: title / branch name format 通過
- [ ] Release workflow: main マージ後にエラーなし（次の feat commit で 0.1.0 PR が作成されることは #6 で確認）

Closes #4