### PR TITLE
feat(preset-base): bundle linters, formatters, hooks, editor and docs scaffolds (v0.1.0)

### DIFF
--- a/packages/preset-base/dist/index.mjs
+++ b/packages/preset-base/dist/index.mjs
@@ -1,8 +1,53 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 //#region src/index.ts
+const templatesDir = resolve(dirname(fileURLToPath(import.meta.url)), "../templates");
+function read(name) {
+	return readFileSync(resolve(templatesDir, name), "utf8");
+}
 const presetBase = {
 	name: "base",
-	files: {},
-	merge: {}
+	files: {
+		"biome.json": read("biome.json"),
+		".markdownlint-cli2.yaml": read(".markdownlint-cli2.yaml"),
+		".yamlfmt.yaml": read(".yamlfmt.yaml"),
+		".yamllint.yaml": read(".yamllint.yaml"),
+		".mdformat.toml": read(".mdformat.toml"),
+		"lefthook-base.yaml": read("lefthook-base.yaml"),
+		"lefthook.yaml": read("lefthook.yaml"),
+		".commitlintrc.yaml": read(".commitlintrc.yaml"),
+		"trivy.yaml": read("trivy.yaml"),
+		".mise.toml": read(".mise.toml"),
+		".editorconfig": read(".editorconfig"),
+		".gitattributes": read(".gitattributes"),
+		".gitignore": read(".gitignore"),
+		LICENSE: read("LICENSE"),
+		"README.md": read("README.md"),
+		"README.ja.md": read("README.ja.md"),
+		"AGENTS.md": read("AGENTS.md"),
+		"CLAUDE.md": read("CLAUDE.md"),
+		"CONTRIBUTING.md": read("CONTRIBUTING.md"),
+		"SECURITY.md": read("SECURITY.md")
+	},
+	merge: { "package.json": {
+		type: "module",
+		engines: { node: ">=22" },
+		scripts: {
+			prepare: "lefthook install || true",
+			lint: "biome check .",
+			"lint:fix": "biome check --write .",
+			"lint:md": "markdownlint-cli2 '**/*.md' '#**/node_modules' '#CHANGELOG.md'",
+			"lint:yaml": "yamllint -c .yamllint.yaml .",
+			"lint:secrets": "gitleaks detect --no-banner",
+			"lint:all": "pnpm run lint && pnpm run lint:md && pnpm run lint:yaml && pnpm run lint:secrets"
+		},
+		devDependencies: {
+			"@biomejs/biome": "^2.4.8",
+			"@commitlint/cli": "^20.0.0",
+			"@commitlint/config-conventional": "^20.0.0"
+		}
+	} }
 };
 //#endregion
 export { presetBase as default };

--- a/packages/preset-base/package.json
+++ b/packages/preset-base/package.json
@@ -48,6 +48,7 @@
     "formatter"
   ],
   "devDependencies": {
+    "@types/node": "^22.10.0",
     "tsdown": "^0.21.7",
     "typescript": "^5.8.0",
     "vitest": "^4.1.1"

--- a/packages/preset-base/src/index.ts
+++ b/packages/preset-base/src/index.ts
@@ -1,21 +1,88 @@
 // @ozzylabs/preset-base — OzzyLabs base preset for create-agentic-app.
 //
-// Initial scaffold (v0.0.0): the preset shape is established but the actual
-// `files` and `merge` content is intentionally empty. Subsequent PRs (handbook#57
-// follow-ups) will populate the bundled tooling configuration described in
-// handbook ADR-0017 § preset-base.
-//
-// Consumers load this preset via create-agentic-app's external preset loader:
+// Bundles shared linters, formatters, git hooks, editor configuration, and
+// document scaffolds. Loaded by CAA via the external preset loader:
 //
 //     // agentic-app.config.json
 //     { "presets": ["@ozzylabs/preset-base"] }
+//
+// See handbook ADR-0017 § preset-base for the bundled inventory.
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Preset } from "./types.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const templatesDir = resolve(here, "../templates");
+
+function read(name: string): string {
+  return readFileSync(resolve(templatesDir, name), "utf8");
+}
 
 const presetBase: Preset = {
   name: "base",
-  files: {},
-  merge: {},
+  files: {
+    // Linter / Formatter
+    "biome.json": read("biome.json"),
+    ".markdownlint-cli2.yaml": read(".markdownlint-cli2.yaml"),
+    ".yamlfmt.yaml": read(".yamlfmt.yaml"),
+    ".yamllint.yaml": read(".yamllint.yaml"),
+    ".mdformat.toml": read(".mdformat.toml"),
+
+    // Git hooks
+    "lefthook-base.yaml": read("lefthook-base.yaml"),
+    "lefthook.yaml": read("lefthook.yaml"),
+
+    // Commit
+    ".commitlintrc.yaml": read(".commitlintrc.yaml"),
+
+    // Security
+    "trivy.yaml": read("trivy.yaml"),
+
+    // Tooling
+    ".mise.toml": read(".mise.toml"),
+
+    // Editor
+    ".editorconfig": read(".editorconfig"),
+    ".gitattributes": read(".gitattributes"),
+    ".gitignore": read(".gitignore"),
+
+    // License
+    LICENSE: read("LICENSE"),
+
+    // Docs scaffold
+    "README.md": read("README.md"),
+    "README.ja.md": read("README.ja.md"),
+    "AGENTS.md": read("AGENTS.md"),
+    "CLAUDE.md": read("CLAUDE.md"),
+    "CONTRIBUTING.md": read("CONTRIBUTING.md"),
+    "SECURITY.md": read("SECURITY.md"),
+  },
+  merge: {
+    "package.json": {
+      type: "module",
+      engines: {
+        node: ">=22",
+      },
+      scripts: {
+        prepare: "lefthook install || true",
+        lint: "biome check .",
+        "lint:fix": "biome check --write .",
+        "lint:md":
+          "markdownlint-cli2 '**/*.md' '#**/node_modules' '#CHANGELOG.md'",
+        "lint:yaml": "yamllint -c .yamllint.yaml .",
+        "lint:secrets": "gitleaks detect --no-banner",
+        "lint:all":
+          "pnpm run lint && pnpm run lint:md && pnpm run lint:yaml && pnpm run lint:secrets",
+      },
+      devDependencies: {
+        "@biomejs/biome": "^2.4.8",
+        "@commitlint/cli": "^20.0.0",
+        "@commitlint/config-conventional": "^20.0.0",
+      },
+    },
+  },
 };
 
 export default presetBase;

--- a/packages/preset-base/templates/.commitlintrc.yaml
+++ b/packages/preset-base/templates/.commitlintrc.yaml
@@ -1,0 +1,2 @@
+extends:
+  - "@commitlint/config-conventional"

--- a/packages/preset-base/templates/.editorconfig
+++ b/packages/preset-base/templates/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/packages/preset-base/templates/.gitattributes
+++ b/packages/preset-base/templates/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize all text files to LF
+* text=auto eol=lf
+
+# Lock files
+pnpm-lock.yaml linguist-generated=true
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.zip binary
+*.tar.gz binary
+*.pdf binary

--- a/packages/preset-base/templates/.gitignore
+++ b/packages/preset-base/templates/.gitignore
@@ -1,0 +1,10 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+*.swp
+*~
+
+# Dependencies
+node_modules/

--- a/packages/preset-base/templates/.markdownlint-cli2.yaml
+++ b/packages/preset-base/templates/.markdownlint-cli2.yaml
@@ -1,0 +1,13 @@
+config:
+  MD013: false
+  MD033:
+    allowed_elements:
+      - details
+      - summary
+      - description
+  MD041: false
+  MD060: false
+
+ignores:
+  - "**/node_modules"
+  - "**/.claude/plans"

--- a/packages/preset-base/templates/.mdformat.toml
+++ b/packages/preset-base/templates/.mdformat.toml
@@ -1,0 +1,2 @@
+wrap = "no"
+end_of_line = "lf"

--- a/packages/preset-base/templates/.mise.toml
+++ b/packages/preset-base/templates/.mise.toml
@@ -1,0 +1,32 @@
+[tools]
+# Runtime & package managers
+node = "24"
+pnpm = "10"
+uv = "0.11"
+
+# Linters & formatters
+biome = "2"
+shellcheck = "0.11"
+shfmt = "3"
+taplo = "0.10"
+"npm:markdownlint-cli2" = "0.21"
+"pipx:yamllint" = "1"
+yamlfmt = "0.21"
+actionlint = "1"
+gitleaks = "8"
+trivy = "0.69"
+"pipx:mdformat" = "0.7"
+
+# CLI utilities for AI-assisted development
+ast-grep = "0.42"
+yq = "4"
+just = "1"
+zoxide = "0.9"
+
+# Testing
+"npm:bats" = "1"
+
+# Git hooks & commit conventions
+lefthook = "2"
+"npm:@commitlint/cli" = "20"
+"npm:@commitlint/config-conventional" = "20"

--- a/packages/preset-base/templates/.yamlfmt.yaml
+++ b/packages/preset-base/templates/.yamlfmt.yaml
@@ -1,0 +1,13 @@
+gitignore_excludes: true
+exclude:
+  - pnpm-lock.yaml
+
+formatter:
+  type: basic
+  indent: 2
+  line_ending: lf
+  retain_line_breaks_single: true
+  max_line_length: 120
+  scan_folded_as_literal: true
+  drop_merge_tag: true
+  pad_line_comments: 1

--- a/packages/preset-base/templates/.yamllint.yaml
+++ b/packages/preset-base/templates/.yamllint.yaml
@@ -1,0 +1,16 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start: disable
+  truthy:
+    allowed-values: ["true", "false", "on"]
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+
+ignore:
+  - node_modules/
+  - pnpm-lock.yaml

--- a/packages/preset-base/templates/AGENTS.md
+++ b/packages/preset-base/templates/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+このファイルは AI エージェント向けの共通 instructions です。
+
+## 基本方針
+
+- 日本語で応答する
+- 推奨案とその理由を提示する
+- `.env` ファイルは読み取り・ステージングしない
+- 破壊的な Git 操作を避ける
+
+## Tech Stack
+
+- Runtime: Node.js (ESM, >= 22)
+- Package manager: pnpm
+- Version management: mise (`.mise.toml`)
+
+## 主要コマンド
+
+```bash
+pnpm install        # 依存関係インストール
+pnpm lint:all       # Biome + markdownlint + yamllint + gitleaks
+```
+
+## 検証（必須）
+
+コード変更後、報告前に以下を通すこと:
+
+1. `pnpm lint:all` — 全リンター通過
+
+## 規約
+
+言語・コミット・ブランチ・PR のルールは README.md を参照すること。

--- a/packages/preset-base/templates/CLAUDE.md
+++ b/packages/preset-base/templates/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+共通方針は AGENTS.md を参照。以下は Claude Code 固有の設定。
+
+## 基本ルール
+
+- ユーザーへの確認には `AskUserQuestion` を使用する

--- a/packages/preset-base/templates/CONTRIBUTING.md
+++ b/packages/preset-base/templates/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
+
+## Bug Reports & Feature Requests
+
+If you find a bug or have an idea for improvement, please open an issue.
+
+## License
+
+By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).

--- a/packages/preset-base/templates/LICENSE
+++ b/packages/preset-base/templates/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ozzy-labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preset-base/templates/README.ja.md
+++ b/packages/preset-base/templates/README.ja.md
@@ -1,0 +1,25 @@
+[English](README.md) | 日本語
+
+# {{PROJECT_NAME}}
+
+{{PROJECT_DESCRIPTION}}
+
+[`@ozzylabs/create-agentic-app`](https://github.com/ozzy-labs/create-agentic-app) と `@ozzylabs/preset-base` で scaffold。
+
+## ローカル開発
+
+```bash
+mise install
+pnpm install
+pnpm lint:all
+```
+
+## 規約
+
+- Commit: [Conventional Commits](https://www.conventionalcommits.org/)（`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`）
+- ブランチ: `<type>/<short-description>`（例: `feat/add-feature`）
+- PR: squash merge のみ、タイトルは Conventional Commits 形式
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/preset-base/templates/README.md
+++ b/packages/preset-base/templates/README.md
@@ -1,0 +1,25 @@
+English | [日本語](README.ja.md)
+
+# {{PROJECT_NAME}}
+
+{{PROJECT_DESCRIPTION}}
+
+Scaffolded with [`@ozzylabs/create-agentic-app`](https://github.com/ozzy-labs/create-agentic-app) using `@ozzylabs/preset-base`.
+
+## Local development
+
+```bash
+mise install
+pnpm install
+pnpm lint:all
+```
+
+## Conventions
+
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`)
+- Branches: `<type>/<short-description>` (e.g. `feat/add-feature`)
+- PRs: squash merge only, title in Conventional Commits format
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/preset-base/templates/SECURITY.md
+++ b/packages/preset-base/templates/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it through [GitHub Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+1. Go to the **Security** tab of this repository
+2. Click **Report a vulnerability**
+3. Fill in the details and submit
+
+We will acknowledge your report within 3 business days and aim to release a fix as soon as possible.
+
+**Please do not open a public issue for security vulnerabilities.**

--- a/packages/preset-base/templates/biome.json
+++ b/packages/preset-base/templates/biome.json
@@ -9,8 +9,7 @@
       "*.json",
       "*.jsonc",
       "!**/node_modules",
-      "!**/dist",
-      "!**/templates"
+      "!**/dist"
     ],
     "ignoreUnknown": true
   },

--- a/packages/preset-base/templates/lefthook-base.yaml
+++ b/packages/preset-base/templates/lefthook-base.yaml
@@ -1,0 +1,34 @@
+# Shared base config from commons
+# Extend this in your repo's lefthook.yaml:
+#
+#   extends:
+#     - lefthook-base.yaml
+#
+# Then add repo-specific commands (biome, taplo, ruff, etc.)
+
+glob_matcher: doublestar
+
+commit-msg:
+  commands:
+    commitlint:
+      run: commitlint --edit {1}
+
+pre-commit:
+  parallel: true
+  commands:
+    shell:
+      glob: "**/*.sh"
+      run: shfmt -w {staged_files} && shellcheck {staged_files}
+      stage_fixed: true
+    markdownlint:
+      glob: "**/*.md"
+      run: markdownlint-cli2 --fix {staged_files}
+      stage_fixed: true
+    yaml:
+      glob: "**/*.{yaml,yml}"
+      run: yamlfmt {staged_files} && yamllint -c .yamllint.yaml {staged_files}
+      stage_fixed: true
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+    trivy:
+      run: trivy fs --scanners vuln,secret --exit-code 1 --no-progress .

--- a/packages/preset-base/templates/lefthook.yaml
+++ b/packages/preset-base/templates/lefthook.yaml
@@ -1,0 +1,2 @@
+extends:
+  - lefthook-base.yaml

--- a/packages/preset-base/templates/trivy.yaml
+++ b/packages/preset-base/templates/trivy.yaml
@@ -1,0 +1,8 @@
+scan:
+  scanners:
+    - vuln
+    - secret
+  skip-dirs:
+    - node_modules
+    - .pnpm-store
+    - .venv

--- a/packages/preset-base/tests/preset.test.ts
+++ b/packages/preset-base/tests/preset.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import preset from "../src/index.js";
+
+describe("@ozzylabs/preset-base", () => {
+  it("declares the canonical preset name", () => {
+    expect(preset.name).toBe("base");
+  });
+
+  it("does not declare requires (it is the root preset)", () => {
+    expect(preset.requires).toBeUndefined();
+  });
+
+  describe("files", () => {
+    const expectedPaths = [
+      "biome.json",
+      ".markdownlint-cli2.yaml",
+      ".yamlfmt.yaml",
+      ".yamllint.yaml",
+      ".mdformat.toml",
+      "lefthook-base.yaml",
+      "lefthook.yaml",
+      ".commitlintrc.yaml",
+      "trivy.yaml",
+      ".mise.toml",
+      ".editorconfig",
+      ".gitattributes",
+      ".gitignore",
+      "LICENSE",
+      "README.md",
+      "README.ja.md",
+      "AGENTS.md",
+      "CLAUDE.md",
+      "CONTRIBUTING.md",
+      "SECURITY.md",
+    ] as const;
+
+    it.each(expectedPaths)("includes %s with non-empty content", (path) => {
+      expect(preset.files[path]).toBeDefined();
+      expect(preset.files[path]?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("LICENSE looks like an MIT license", () => {
+      expect(preset.files.LICENSE).toContain("MIT License");
+      expect(preset.files.LICENSE).toContain("Permission is hereby granted");
+    });
+
+    it("biome.json is valid JSON", () => {
+      expect(() => JSON.parse(preset.files["biome.json"] ?? "")).not.toThrow();
+    });
+
+    it("lefthook.yaml extends lefthook-base.yaml", () => {
+      expect(preset.files["lefthook.yaml"]).toContain("lefthook-base.yaml");
+    });
+
+    it(".commitlintrc.yaml extends @commitlint/config-conventional", () => {
+      expect(preset.files[".commitlintrc.yaml"]).toContain(
+        "@commitlint/config-conventional",
+      );
+    });
+  });
+
+  describe("merge", () => {
+    it("targets package.json with the documented script set", () => {
+      const pkg = preset.merge["package.json"] as {
+        scripts: Record<string, string>;
+        devDependencies: Record<string, string>;
+        engines: Record<string, string>;
+      };
+
+      expect(pkg.scripts.lint).toBeDefined();
+      expect(pkg.scripts["lint:all"]).toContain("lint:md");
+      expect(pkg.scripts["lint:secrets"]).toContain("gitleaks");
+      expect(pkg.scripts.prepare).toContain("lefthook install");
+      expect(pkg.devDependencies["@biomejs/biome"]).toBeDefined();
+      expect(pkg.devDependencies["@commitlint/cli"]).toBeDefined();
+      expect(pkg.engines.node).toBe(">=22");
+    });
+  });
+});

--- a/packages/preset-base/tsconfig.json
+++ b/packages/preset-base/tsconfig.json
@@ -12,5 +12,5 @@
     "declaration": true,
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   packages/preset-base:
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
       tsdown:
         specifier: ^0.21.7
         version: 0.21.10(typescript@5.9.3)
@@ -28,7 +31,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+        version: 4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
 
   packages/preset-cli:
     devDependencies:
@@ -386,6 +389,9 @@ packages:
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -914,6 +920,9 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
@@ -1339,6 +1348,10 @@ snapshots:
 
   '@types/jsesc@2.5.1': {}
 
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -1351,6 +1364,14 @@ snapshots:
       '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)
 
   '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
@@ -1780,11 +1801,25 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
+  undici-types@6.21.0: {}
+
   undici-types@7.19.2: {}
 
   unrun@0.2.37:
     dependencies:
       rolldown: 1.0.0-rc.17
+
+  vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.1
 
   vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1):
     dependencies:
@@ -1797,6 +1832,33 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:


### PR DESCRIPTION
## Summary

ADR-0017 § preset-base に従い、scaffold v0.0.0 で形状だけ確立していた `@ozzylabs/preset-base` の中身を populate する。CAA の external preset loader が consume する `Preset.files` / `Preset.merge` に同梱物を反映。

### files (templates ディレクトリから runtime 読み込み)

`import.meta.url` から `../templates` を解決し、`readFileSync` で 20 ファイルを `files` に詰める。templates は `package.json` の `files` 配列に既に含まれているため npm publish で同梱される。

| カテゴリ | ファイル |
| --- | --- |
| Linter / Formatter | `biome.json`, `.markdownlint-cli2.yaml`, `.yamlfmt.yaml`, `.yamllint.yaml`, `.mdformat.toml` |
| Git hooks | `lefthook-base.yaml`, `lefthook.yaml`（lefthook-base.yaml を extends） |
| Commit | `.commitlintrc.yaml`（@commitlint/config-conventional を extends） |
| Security | `trivy.yaml` |
| Tooling | `.mise.toml` |
| Editor | `.editorconfig`, `.gitattributes`, `.gitignore` |
| License | `LICENSE`（MIT） |
| Docs scaffold | `README.md`, `README.ja.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md` |

Docs scaffold は consumer 向けの汎用版で、`{{PROJECT_NAME}}` / `{{PROJECT_DESCRIPTION}}` プレースホルダを残し、CAA 側で置換する想定。

### merge (package.json への追記)

| 種別 | 内容 |
| --- | --- |
| scripts | `prepare`（lefthook install）, `lint`, `lint:fix`, `lint:md`, `lint:yaml`, `lint:secrets`, `lint:all` |
| devDependencies | `@biomejs/biome`, `@commitlint/cli`, `@commitlint/config-conventional` |
| engines | `node: ">=22"` |
| type | `module` |

### Tests (vitest, 27 ケース)

- `preset.name === "base"` / `requires === undefined`
- 期待される 20 ファイルパスがすべて含まれかつ非空
- `LICENSE` が MIT、`biome.json` が valid JSON、`lefthook.yaml` が `lefthook-base.yaml` を extends、`.commitlintrc.yaml` が `@commitlint/config-conventional` を extends
- `merge.package.json` の scripts/devDeps/engines 形状

### Tooling adjustments

- `@types/node` を devDep に追加（`node:fs` / `import.meta.url` 型解決のため）
- `tsconfig.json` の `include` に `tests/**` を追加
- root `biome.json` の `files.includes` に `!**/templates` を追加（template 同梱の `biome.json` が nested root config として検出されるのを抑止）

### release-please

本 PR は `feat(preset-base):` で始まる scope 付きコミット。マージ後の release workflow で `packages/preset-base` の v0.1.0 release PR が生成されるはず（#4 で manifest を 0.0.1 に bump し、`bump-patch-for-minor-pre-major` を削除済み）。マージ後の release workflow 結果を確認すること。

## Test plan

- [x] `pnpm -r run typecheck` 通過
- [x] `pnpm -r run build` 通過（dist/index.mjs で `import.meta.url` が保持されることを確認）
- [x] `pnpm -r run test` 通過（preset-base 27 件 pass）
- [x] `pnpm run lint:all` 通過
- [x] dist 経由のスモーク: `node -e "import('./dist/index.mjs')..."` で `name: base`, `file count: 20` 確認
- [ ] CI 全 jobs 緑
- [ ] PR Check 通過
- [ ] マージ後: release-please が preset-base v0.1.0 PR を作成

Closes #6