### PR TITLE
feat(preset-web): bundle Astro + React + Tailwind + Vite baseline (v0.1.0)

### DIFF
--- a/packages/preset-web/dist/index.mjs
+++ b/packages/preset-web/dist/index.mjs
@@ -1,9 +1,49 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 //#region src/index.ts
+const templatesDir = resolve(dirname(fileURLToPath(import.meta.url)), "../templates");
+function read(name) {
+	return readFileSync(resolve(templatesDir, name), "utf8");
+}
 const presetWeb = {
 	name: "web",
-	files: {},
-	merge: {},
-	requires: ["@ozzylabs/preset-base"]
+	requires: ["@ozzylabs/preset-base"],
+	files: {
+		"astro.config.mjs": read("astro.config.mjs"),
+		"tsconfig.json": read("tsconfig.json"),
+		"src/styles/global.css": read("src/styles/global.css"),
+		".vscode/settings.json": read(".vscode/settings.json")
+	},
+	merge: {
+		"package.json": {
+			type: "module",
+			scripts: {
+				dev: "astro dev",
+				build: "astro build",
+				preview: "astro preview",
+				astro: "astro",
+				typecheck: "astro check"
+			},
+			dependencies: {
+				astro: "^5.0.0",
+				react: "^19.0.0",
+				"react-dom": "^19.0.0",
+				"@astrojs/react": "^4.0.0",
+				"@tailwindcss/vite": "^4.0.0",
+				tailwindcss: "^4.0.0"
+			},
+			devDependencies: {
+				"@types/react": "^19.0.0",
+				"@types/react-dom": "^19.0.0"
+			}
+		},
+		".gitignore": [
+			"dist/",
+			".astro/",
+			"*.tsbuildinfo"
+		]
+	}
 };
 //#endregion
 export { presetWeb as default };

--- a/packages/preset-web/package.json
+++ b/packages/preset-web/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@ozzylabs/preset-base": "workspace:*",
+    "@types/node": "^22.10.0",
     "tsdown": "^0.21.7",
     "typescript": "^5.8.0",
     "vitest": "^4.1.1"

--- a/packages/preset-web/src/index.ts
+++ b/packages/preset-web/src/index.ts
@@ -1,22 +1,66 @@
 // @ozzylabs/preset-web — OzzyLabs web preset for create-agentic-app.
 //
-// Initial scaffold (v0.0.0): the preset shape is established but the actual
-// `files` and `merge` content is intentionally empty. Subsequent PRs will
-// populate Astro / React / Tailwind / Vite configuration described in
-// handbook ADR-0017 § preset-web.
-//
-// Consumers load this preset (and its required base) via:
+// Bundles Astro + React + Tailwind CSS + Vite baseline configuration on top
+// of `@ozzylabs/preset-base`. Loaded by CAA via the external preset loader:
 //
 //     // agentic-app.config.json
 //     { "presets": ["@ozzylabs/preset-base", "@ozzylabs/preset-web"] }
+//
+// See handbook ADR-0017 § preset-web for the bundled inventory.
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Preset } from "@ozzylabs/preset-base";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const templatesDir = resolve(here, "../templates");
+
+function read(name: string): string {
+  return readFileSync(resolve(templatesDir, name), "utf8");
+}
 
 const presetWeb: Preset = {
   name: "web",
-  files: {},
-  merge: {},
   requires: ["@ozzylabs/preset-base"],
+  files: {
+    // Framework
+    "astro.config.mjs": read("astro.config.mjs"),
+
+    // TS
+    "tsconfig.json": read("tsconfig.json"),
+
+    // Styling
+    "src/styles/global.css": read("src/styles/global.css"),
+
+    // Editor
+    ".vscode/settings.json": read(".vscode/settings.json"),
+  },
+  merge: {
+    "package.json": {
+      type: "module",
+      scripts: {
+        dev: "astro dev",
+        build: "astro build",
+        preview: "astro preview",
+        astro: "astro",
+        typecheck: "astro check",
+      },
+      dependencies: {
+        astro: "^5.0.0",
+        react: "^19.0.0",
+        "react-dom": "^19.0.0",
+        "@astrojs/react": "^4.0.0",
+        "@tailwindcss/vite": "^4.0.0",
+        tailwindcss: "^4.0.0",
+      },
+      devDependencies: {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+      },
+    },
+    ".gitignore": ["dist/", ".astro/", "*.tsbuildinfo"],
+  },
 };
 
 export default presetWeb;

--- a/packages/preset-web/templates/.vscode/settings.json
+++ b/packages/preset-web/templates/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
+  },
+  "tailwindCSS.experimental.classRegex": [
+    ["class:\\s*?[\"'`]([^\"'`]*).*?,"],
+    ["className=\\{?[\"'`]([^\"'`]*).*?\\}?"]
+  ]
+}

--- a/packages/preset-web/templates/astro.config.mjs
+++ b/packages/preset-web/templates/astro.config.mjs
@@ -1,0 +1,11 @@
+// @ts-check
+import { defineConfig } from "astro/config";
+import react from "@astrojs/react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  integrations: [react()],
+  vite: {
+    plugins: [tailwindcss()],
+  },
+});

--- a/packages/preset-web/templates/src/styles/global.css
+++ b/packages/preset-web/templates/src/styles/global.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/preset-web/templates/tsconfig.json
+++ b/packages/preset-web/templates/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "*.config.*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/preset-web/tests/preset.test.ts
+++ b/packages/preset-web/tests/preset.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import preset from "../src/index.js";
+
+describe("@ozzylabs/preset-web", () => {
+  it("declares the canonical preset name", () => {
+    expect(preset.name).toBe("web");
+  });
+
+  it("requires preset-base", () => {
+    expect(preset.requires).toEqual(["@ozzylabs/preset-base"]);
+  });
+
+  describe("files", () => {
+    const expectedPaths = [
+      "astro.config.mjs",
+      "tsconfig.json",
+      "src/styles/global.css",
+      ".vscode/settings.json",
+    ] as const;
+
+    it.each(expectedPaths)("includes %s with non-empty content", (path) => {
+      expect(preset.files[path]).toBeDefined();
+      expect(preset.files[path]?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("astro.config.mjs wires the React integration and tailwindcss vite plugin", () => {
+      const cfg = preset.files["astro.config.mjs"] ?? "";
+      expect(cfg).toContain("@astrojs/react");
+      expect(cfg).toContain("@tailwindcss/vite");
+    });
+
+    it("tsconfig.json extends astro/tsconfigs/strict and uses jsx react-jsx", () => {
+      const tsconfig = JSON.parse(preset.files["tsconfig.json"] ?? "{}");
+      expect(tsconfig.extends).toBe("astro/tsconfigs/strict");
+      expect(tsconfig.compilerOptions.jsx).toBe("react-jsx");
+    });
+
+    it("global.css imports tailwindcss", () => {
+      expect(preset.files["src/styles/global.css"]).toContain(
+        '@import "tailwindcss"',
+      );
+    });
+
+    it(".vscode/settings.json is valid JSON with biome formatter default", () => {
+      const settings = JSON.parse(preset.files[".vscode/settings.json"] ?? "{}");
+      expect(settings["editor.defaultFormatter"]).toBe("biomejs.biome");
+    });
+  });
+
+  describe("merge", () => {
+    it("adds astro/react/tailwind dependencies and dev/build/preview scripts", () => {
+      const pkg = preset.merge["package.json"] as {
+        scripts: Record<string, string>;
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+      };
+
+      expect(pkg.scripts.dev).toBe("astro dev");
+      expect(pkg.scripts.build).toBe("astro build");
+      expect(pkg.scripts.preview).toBe("astro preview");
+      expect(pkg.dependencies.astro).toBeDefined();
+      expect(pkg.dependencies.react).toBeDefined();
+      expect(pkg.dependencies["@astrojs/react"]).toBeDefined();
+      expect(pkg.dependencies["@tailwindcss/vite"]).toBeDefined();
+      expect(pkg.dependencies.tailwindcss).toBeDefined();
+      expect(pkg.devDependencies["@types/react"]).toBeDefined();
+    });
+
+    it("appends Astro-specific entries to .gitignore", () => {
+      expect(preset.merge[".gitignore"]).toEqual(
+        expect.arrayContaining(["dist/", ".astro/", "*.tsbuildinfo"]),
+      );
+    });
+  });
+});

--- a/packages/preset-web/tsconfig.json
+++ b/packages/preset-web/tsconfig.json
@@ -12,5 +12,5 @@
     "declaration": true,
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@ozzylabs/preset-base':
         specifier: workspace:*
         version: link:../preset-base
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
       tsdown:
         specifier: ^0.21.7
         version: 0.21.10(typescript@5.9.3)
@@ -61,7 +64,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+        version: 4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
 
 packages:
 


### PR DESCRIPTION
## Summary

ADR-0017 § preset-web に従い、scaffold v0.0.0 で形状だけ確立していた `@ozzylabs/preset-web` の中身を populate する。`@ozzylabs/preset-base` を `requires` で参照し、Astro + React + Tailwind + Vite の baseline を提供。

### files (templates dir, runtime 読み込み)

| カテゴリ | パス | 内容 |
| --- | --- | --- |
| Framework | `astro.config.mjs` | `@astrojs/react` integration + `@tailwindcss/vite` プラグイン登録 |
| TS | `tsconfig.json` | `astro/tsconfigs/strict` を extends、`jsx: "react-jsx"`、`jsxImportSource: "react"` |
| Styling | `src/styles/global.css` | `@import "tailwindcss"` |
| Editor | `.vscode/settings.json` | `biomejs.biome` を default formatter、Astro override、Tailwind class regex |

### merge

| 対象 | 内容 |
| --- | --- |
| `package.json` | scripts: `dev` / `build` / `preview` / `astro` / `typecheck`<br>dependencies: `astro`, `react`, `react-dom`, `@astrojs/react`, `@tailwindcss/vite`, `tailwindcss`<br>devDependencies: `@types/react`, `@types/react-dom` |
| `.gitignore` | `dist/`, `.astro/`, `*.tsbuildinfo` を append |

### Tests (vitest, 12 ケース)

- `preset.name === "web"` / `requires === ["@ozzylabs/preset-base"]`
- 期待される 4 ファイルパスがすべて含まれかつ非空
- `astro.config.mjs` が `@astrojs/react` と `@tailwindcss/vite` を含むこと
- `tsconfig.json` が astro strict を extends し `jsx: react-jsx` であること
- `global.css` が `tailwindcss` を import すること
- `.vscode/settings.json` が valid JSON で `biomejs.biome` を formatter にすること
- `merge.package.json` の scripts/deps と `.gitignore` の append entries

### Tooling

- `@types/node` を devDep に追加
- `tsconfig.json` の `include` に `tests/**` を追加

### release-please

`feat(preset-web):` で始まる scope 付きコミット。マージ後の release workflow で `packages/preset-web` の v0.1.0 release PR が更新される（既存 #11）。

### Note

`packages/preset-web/templates/.vscode/settings.json` はコミット作者の global gitignore に `.vscode/` があり初回 commit で漏れたため、別 commit で `git add -f` で追加している（PR レビューに含まれる）。

## Test plan

- [x] `pnpm --filter @ozzylabs/preset-web run typecheck` 通過
- [x] `pnpm --filter @ozzylabs/preset-web run build` 通過
- [x] `pnpm --filter @ozzylabs/preset-web run test` 通過（12 件 pass）
- [x] `pnpm run lint:all` 通過
- [ ] CI 全 jobs 緑
- [ ] PR Check 通過
- [ ] マージ後: release-please が preset-web v0.1.0 PR を更新

Closes #7