### PR TITLE
feat(preset-cli): bundle tsdown + @clack/prompts + vitest baseline (v0.1.0)

### DIFF
--- a/packages/preset-cli/dist/index.mjs
+++ b/packages/preset-cli/dist/index.mjs
@@ -1,9 +1,47 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 //#region src/index.ts
+const templatesDir = resolve(dirname(fileURLToPath(import.meta.url)), "../templates");
+function read(name) {
+	return readFileSync(resolve(templatesDir, name), "utf8");
+}
 const presetCli = {
 	name: "cli",
-	files: {},
-	merge: {},
-	requires: ["@ozzylabs/preset-base"]
+	requires: ["@ozzylabs/preset-base"],
+	files: {
+		"tsdown.config.ts": read("tsdown.config.ts"),
+		"tsconfig.json": read("tsconfig.json"),
+		"vitest.config.ts": read("vitest.config.ts"),
+		"src/cli.ts": read("src/cli.ts"),
+		"tests/cli.test.ts": read("tests/cli.test.ts")
+	},
+	merge: {
+		"package.json": {
+			type: "module",
+			bin: { "{{PROJECT_NAME}}": "./dist/cli.mjs" },
+			main: "./dist/cli.mjs",
+			files: ["dist"],
+			engines: { node: ">=22" },
+			packageManager: "pnpm@10.32.1",
+			scripts: {
+				build: "tsdown",
+				dev: "tsdown --watch",
+				start: "node ./dist/cli.mjs",
+				test: "vitest run",
+				"test:watch": "vitest",
+				typecheck: "tsc --noEmit"
+			},
+			dependencies: { "@clack/prompts": "^0.9.0" },
+			devDependencies: {
+				"@types/node": "^22.10.0",
+				tsdown: "^0.21.7",
+				typescript: "^5.8.0",
+				vitest: "^4.1.1"
+			}
+		},
+		".gitignore": ["dist/", "*.tsbuildinfo"]
+	}
 };
 //#endregion
 export { presetCli as default };

--- a/packages/preset-cli/package.json
+++ b/packages/preset-cli/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@ozzylabs/preset-base": "workspace:*",
+    "@types/node": "^22.10.0",
     "tsdown": "^0.21.7",
     "typescript": "^5.8.0",
     "vitest": "^4.1.1"

--- a/packages/preset-cli/src/index.ts
+++ b/packages/preset-cli/src/index.ts
@@ -1,22 +1,81 @@
 // @ozzylabs/preset-cli — OzzyLabs Node.js CLI preset for create-agentic-app.
 //
-// Initial scaffold (v0.0.0): the preset shape is established but the actual
-// `files` and `merge` content is intentionally empty. Subsequent PRs will
-// populate the tsdown / @clack/prompts / vitest / CLI package.json template
-// described in handbook ADR-0017 § preset-cli.
-//
-// Consumers load this preset (and its required base) via:
+// Bundles tsdown + @clack/prompts + vitest baseline for shipping a Node.js
+// CLI on top of `@ozzylabs/preset-base`. Loaded by CAA via the external
+// preset loader:
 //
 //     // agentic-app.config.json
 //     { "presets": ["@ozzylabs/preset-base", "@ozzylabs/preset-cli"] }
+//
+// CAA distinguishes a CLI consumer from a library consumer by the presence
+// of a `bin` entry in the merged package.json — this preset always merges
+// one in via `merge["package.json"].bin`.
+//
+// See handbook ADR-0017 § preset-cli for the bundled inventory.
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Preset } from "@ozzylabs/preset-base";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const templatesDir = resolve(here, "../templates");
+
+function read(name: string): string {
+  return readFileSync(resolve(templatesDir, name), "utf8");
+}
 
 const presetCli: Preset = {
   name: "cli",
-  files: {},
-  merge: {},
   requires: ["@ozzylabs/preset-base"],
+  files: {
+    // Build
+    "tsdown.config.ts": read("tsdown.config.ts"),
+
+    // TS
+    "tsconfig.json": read("tsconfig.json"),
+
+    // Test
+    "vitest.config.ts": read("vitest.config.ts"),
+
+    // Entry
+    "src/cli.ts": read("src/cli.ts"),
+
+    // Smoke test
+    "tests/cli.test.ts": read("tests/cli.test.ts"),
+  },
+  merge: {
+    "package.json": {
+      type: "module",
+      bin: {
+        "{{PROJECT_NAME}}": "./dist/cli.mjs",
+      },
+      main: "./dist/cli.mjs",
+      files: ["dist"],
+      engines: {
+        node: ">=22",
+      },
+      packageManager: "pnpm@10.32.1",
+      scripts: {
+        build: "tsdown",
+        dev: "tsdown --watch",
+        start: "node ./dist/cli.mjs",
+        test: "vitest run",
+        "test:watch": "vitest",
+        typecheck: "tsc --noEmit",
+      },
+      dependencies: {
+        "@clack/prompts": "^0.9.0",
+      },
+      devDependencies: {
+        "@types/node": "^22.10.0",
+        tsdown: "^0.21.7",
+        typescript: "^5.8.0",
+        vitest: "^4.1.1",
+      },
+    },
+    ".gitignore": ["dist/", "*.tsbuildinfo"],
+  },
 };
 
 export default presetCli;

--- a/packages/preset-cli/templates/src/cli.ts
+++ b/packages/preset-cli/templates/src/cli.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { intro, outro, text } from "@clack/prompts";
+
+async function main(): Promise<void> {
+  intro("{{PROJECT_NAME}}");
+
+  const name = await text({
+    message: "What is your name?",
+    placeholder: "world",
+    defaultValue: "world",
+  });
+
+  outro(`Hello, ${String(name)}!`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/preset-cli/templates/tests/cli.test.ts
+++ b/packages/preset-cli/templates/tests/cli.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("cli smoke", () => {
+  it("imports the entry without throwing", async () => {
+    await expect(import("../src/cli.js")).resolves.toBeDefined();
+  });
+});

--- a/packages/preset-cli/templates/tsconfig.json
+++ b/packages/preset-cli/templates/tsconfig.json
@@ -10,7 +10,8 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "declaration": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*", "tests/**/*", "*.config.ts"]
 }

--- a/packages/preset-cli/templates/tsdown.config.ts
+++ b/packages/preset-cli/templates/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/cli.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  outDir: "dist",
+  shims: true,
+  platform: "node",
+  target: "node22",
+});

--- a/packages/preset-cli/templates/vitest.config.ts
+++ b/packages/preset-cli/templates/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/preset-cli/tests/preset.test.ts
+++ b/packages/preset-cli/tests/preset.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import preset from "../src/index.js";
+
+describe("@ozzylabs/preset-cli", () => {
+  it("declares the canonical preset name", () => {
+    expect(preset.name).toBe("cli");
+  });
+
+  it("requires preset-base", () => {
+    expect(preset.requires).toEqual(["@ozzylabs/preset-base"]);
+  });
+
+  describe("files", () => {
+    const expectedPaths = [
+      "tsdown.config.ts",
+      "tsconfig.json",
+      "vitest.config.ts",
+      "src/cli.ts",
+      "tests/cli.test.ts",
+    ] as const;
+
+    it.each(expectedPaths)("includes %s with non-empty content", (path) => {
+      expect(preset.files[path]).toBeDefined();
+      expect(preset.files[path]?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it("tsdown.config.ts targets node22 and emits dts", () => {
+      const cfg = preset.files["tsdown.config.ts"] ?? "";
+      expect(cfg).toContain("target: \"node22\"");
+      expect(cfg).toContain("dts: true");
+    });
+
+    it("src/cli.ts is a Node shebanged entry that uses @clack/prompts", () => {
+      const entry = preset.files["src/cli.ts"] ?? "";
+      expect(entry.startsWith("#!/usr/bin/env node")).toBe(true);
+      expect(entry).toContain("@clack/prompts");
+    });
+
+    it("tsconfig.json is valid JSON with bundler moduleResolution", () => {
+      const tsconfig = JSON.parse(preset.files["tsconfig.json"] ?? "{}");
+      expect(tsconfig.compilerOptions.moduleResolution).toBe("Bundler");
+    });
+  });
+
+  describe("merge", () => {
+    it("merges a CLI-shaped package.json (bin entry, build/test scripts, @clack/prompts)", () => {
+      const pkg = preset.merge["package.json"] as {
+        type: string;
+        bin: Record<string, string>;
+        engines: Record<string, string>;
+        packageManager: string;
+        scripts: Record<string, string>;
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+        files: string[];
+      };
+
+      expect(pkg.type).toBe("module");
+      expect(Object.values(pkg.bin)).toContain("./dist/cli.mjs");
+      expect(pkg.engines.node).toBe(">=22");
+      expect(pkg.packageManager.startsWith("pnpm@")).toBe(true);
+      expect(pkg.scripts.build).toBe("tsdown");
+      expect(pkg.scripts.test).toBe("vitest run");
+      expect(pkg.dependencies["@clack/prompts"]).toBeDefined();
+      expect(pkg.devDependencies.tsdown).toBeDefined();
+      expect(pkg.devDependencies.vitest).toBeDefined();
+      expect(pkg.files).toContain("dist");
+    });
+
+    it("appends CLI-specific entries to .gitignore", () => {
+      expect(preset.merge[".gitignore"]).toEqual(
+        expect.arrayContaining(["dist/", "*.tsbuildinfo"]),
+      );
+    });
+  });
+});

--- a/packages/preset-cli/vitest.config.ts
+++ b/packages/preset-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@ozzylabs/preset-base':
         specifier: workspace:*
         version: link:../preset-base
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
       tsdown:
         specifier: ^0.21.7
         version: 0.21.10(typescript@5.9.3)
@@ -46,7 +49,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+        version: 4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
 
   packages/preset-web:
     devDependencies:
@@ -1376,14 +1379,6 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))':
-    dependencies:
-      '@vitest/spy': 4.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)
-
   '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
@@ -1824,18 +1819,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.6.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-
   vitest@4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
@@ -1860,33 +1843,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)):
-    dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary

ADR-0017 § preset-cli に従い、scaffold v0.0.0 で形状だけ確立していた `@ozzylabs/preset-cli` の中身を populate する。`@ozzylabs/preset-base` を `requires` で参照し、Node.js CLI 用の baseline (tsdown + @clack/prompts + vitest) を提供。

### CAA における preset-cli の判別基準

`merge.package.json.bin` を必ず付与することで、CAA は `bin` entry の有無で「CLI consumer」と判断する（issue #8 § 判別基準）。プレースホルダ `{{PROJECT_NAME}}` は CAA 側で置換。

### files (templates dir, runtime 読み込み)

| カテゴリ | パス | 内容 |
| --- | --- | --- |
| Build | `tsdown.config.ts` | entry `src/cli.ts`, ESM, dts, node22, shims |
| TS | `tsconfig.json` | strict / Bundler / `types: ["node"]` / `tests/**` 含む |
| Test | `vitest.config.ts` | include `tests/**/*.test.ts` |
| Entry | `src/cli.ts` | `#!/usr/bin/env node` shebang、`@clack/prompts` 利用デモ |
| Smoke | `tests/cli.test.ts` | エントリの import が throw しないこと |

### merge

| 対象 | 内容 |
| --- | --- |
| `package.json` | `type: "module"`, `engines.node >= 22`, `packageManager: pnpm@10.32.1`<br>`bin: { "{{PROJECT_NAME}}": "./dist/cli.mjs" }`, `main`, `files: ["dist"]`<br>scripts: `build`, `dev`, `start`, `test`, `test:watch`, `typecheck`<br>dependencies: `@clack/prompts`<br>devDependencies: `tsdown`, `typescript`, `vitest`, `@types/node` |
| `.gitignore` | `dist/`, `*.tsbuildinfo` を append |

### Tests (vitest, 12 ケース)

- `preset.name === "cli"` / `requires === ["@ozzylabs/preset-base"]`
- 期待される 5 ファイルパスがすべて含まれかつ非空
- `tsdown.config.ts` が `target: "node22"` と `dts: true` を含むこと
- `src/cli.ts` が `#!/usr/bin/env node` で始まり `@clack/prompts` を使うこと
- `tsconfig.json` が `Bundler` moduleResolution であること
- `merge.package.json` の type/bin/scripts/deps、`.gitignore` の append entries

### Tooling

- `vitest.config.ts` を package root に追加し `include: ["tests/**/*.test.ts"]` に絞り込み（templates/tests/ にある consumer 向けテストファイルが preset 自身の test 実行で拾われるのを防ぐ）
- `@types/node` を devDep に追加
- `tsconfig.json` の `include` に `tests/**` を追加

### release-please

`feat(preset-cli):` で始まる scope 付きコミット。マージ後の release workflow で `packages/preset-cli` の v0.1.0 release PR が更新される（既存 #10）。

## Test plan

- [x] `pnpm --filter @ozzylabs/preset-cli run typecheck` 通過
- [x] `pnpm --filter @ozzylabs/preset-cli run build` 通過
- [x] `pnpm --filter @ozzylabs/preset-cli run test` 通過（12 件 pass）
- [x] `pnpm -r run test` 通過（base 27 + web 12 + cli 12）
- [x] `pnpm run lint:all` 通過
- [ ] CI 全 jobs 緑
- [ ] PR Check 通過
- [ ] マージ後: release-please が preset-cli v0.1.0 PR を更新

Closes #8