### PR TITLE
chore(commons): sync to latest

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,9 +1,7 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: b5b5844ef0ee5e4c5c7ea3e739c675bbc04d38f2
-synced_at: 2026-04-25T08:30:00Z
-# Auto-updated by Renovate (extends github>ozzy-labs/skills//skills-sync)
-skills_commit: c600d8621e46dd1435133d5498a63f96776fdeed
+commit: a32c498f106b8684e2419ab7861e95e1bbef5445
+synced_at: 2026-04-26T07:19:40Z
 pinned:
   - CLAUDE.md
   - AGENTS.md

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,41 @@
+name: バグ報告
+description: 再現手順付きのバグ報告
+labels: ["fix"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: バグの内容を簡潔に記述してください。
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 再現手順
+      description: バグを再現する手順を記述してください。
+      placeholder: |
+        1. ... を実行
+        2. ... を選択
+        3. エラーが発生
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+      description: 本来どのように動作すべきか。
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      description: 実際に何が起きたか。
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: 補足情報
+      description: OS、ランタイムバージョン、スクリーンショットなど。

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,33 @@
+name: 機能リクエスト
+description: 新機能や改善の提案
+labels: ["feat"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 機能や改善の内容を簡潔に記述してください。
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 背景・動機
+      description: なぜこの機能が必要か。どのような問題を解決するか。
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案する解決策
+      description: この機能がどのように動作すべきか。
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 検討した代替案
+      description: 検討した他の解決策やアプローチ。
+  - type: textarea
+    id: context
+    attributes:
+      label: 補足情報
+      description: モックアップ、参考資料など。

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# GitHub Copilot Instructions
+
+共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
+GitHub Copilot Chat / Copilot コーディングエージェントは本ファイルを自動で読み込みます。
+
+## 基本ルール
+
+- 日本語で応答する
+- 推奨案とその理由を提示する
+- `.env` ファイルは読み取り・ステージングしない
+- 破壊的な Git 操作を避ける
+
+## コミット・ブランチ・PR
+
+- Conventional Commits 形式（`<type>[scope]: <description>`）
+- ブランチ命名: `<type>/<short-description>`
+- PR はタイトルをコミット規約と同じ形式にする
+- マージ方法は squash merge のみ
+
+## 検証
+
+変更後は以下を通すこと:
+
+```bash
+mise exec -- lefthook run pre-commit --all-files
+```
+
+プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] CI/CD
+- [ ] Dependencies
+
+## Testing
+
+<!-- How was this tested? -->
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] Linters pass
+- [ ] Self-reviewed

--- a/.github/workflows/sync-commons.yaml
+++ b/.github/workflows/sync-commons.yaml
@@ -4,14 +4,14 @@ name: Sync commons
 #
 # Runs on a weekly schedule (configurable) and on manual dispatch. When
 # the upstream commons repo has changes that are not yet reflected
-# in this repo (per `.commons/sync.yaml` state, minus `pinned`
-# entries), the workflow runs `sync.sh --yes` and opens a pull request
-# with the resulting diff. The PR is never auto-merged; review it.
+# in this repo (per `.commons/sync.yaml`, minus `pinned` entries), the
+# workflow runs `sync.sh --yes` and opens a pull request with the
+# resulting diff. The PR is never auto-merged; review it.
 #
 # Prerequisites in the consumer repo:
 #   - Workflow permissions must allow creating PRs (usually set by
 #     commons/setup-repo.sh)
-#   - `.commons/sync.yaml` exists (created on first manual sync.sh run)
+#   - `.commons/sync.yaml` exists (created on first manual sync.sh run).
 on:
   schedule:
     # Every Monday 00:00 UTC

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@2.1.6"]
+    }
+  }
+}

--- a/.mise.toml
+++ b/.mise.toml
@@ -17,14 +17,14 @@ gitleaks = "8"
 trivy = "0.69"
 "pipx:mdformat" = "0.7"
 
+# Testing
+"npm:bats" = "1"
+
 # CLI utilities for AI-assisted development
 ast-grep = "0.42"
 yq = "4"
 just = "1"
 zoxide = "0.9"
-
-# Testing
-"npm:bats" = "1"
 
 # Git hooks & commit conventions
 lefthook = "2"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "DavidAnson.vscode-markdownlint",
+    "EditorConfig.EditorConfig",
+    "foxundermoon.shell-format",
+    "github.vscode-github-actions",
+    "redhat.vscode-yaml",
+    "tamasfe.even-better-toml",
+    "timonwong.shellcheck"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,42 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.biome": "explicit"
+  },
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "search.exclude": {
+    "**/dist": true
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[markdown]": {
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "explicit"
+    }
+  },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  }
+}


### PR DESCRIPTION
Sync commons configuration to latest version (a32c498). Major update from v0 (b5b5844) which includes skills extraction to dedicated repo and Renovate commons-sync preset.

## Changes

- **new**: `.github/ISSUE_TEMPLATE/bug_report.yaml`
- **new**: `.github/ISSUE_TEMPLATE/feature_request.yaml`
- **new**: `.github/copilot-instructions.md`
- **new**: `.github/pull_request_template.md`
- **new**: `.mcp.json`
- **new**: `.vscode/extensions.json`
- **new**: `.vscode/settings.json`
- **updated**: `.github/workflows/sync-commons.yaml`
- **updated**: `.mise.toml`