### PR TITLE
chore(sync): pin .github/workflows/* to fix sync-commons failures

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -19,3 +19,5 @@ pinned:
   - biome.json
   - renovate.json
   - .gitignore
+  - .github/workflows/pr-check.yaml
+  - .github/workflows/sync-commons.yaml


### PR DESCRIPTION
## Summary

- `.commons/sync.yaml` の `pinned` に `.github/workflows/pr-check.yaml` と `.github/workflows/sync-commons.yaml` を追加
- `GITHUB_TOKEN` の `workflows` 権限不足で Sync commons workflow が remote rejected されていた問題を修正
- 詳細は ozzy-labs/commons#95 の pinned 戦略を参照

Closes #23

## Test plan

- [x] `.commons/sync.yaml` の YAML 妥当性は lefthook で検証済
- [ ] マージ後、次回スケジュール（毎週月曜 00:00 UTC）で sync-commons の成功を確認