### PR TITLE
chore: sync commons defaults

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,10 +1,8 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: a32c498f106b8684e2419ab7861e95e1bbef5445
-synced_at: 2026-04-26T07:19:40Z
-# Auto-updated by Renovate
+commit: 7c831aa4e3c35428d6e4bcc31a216aa682c0fb25
+synced_at: 2026-05-05T10:20:38Z
 skills_commit: 4d35fa3683789c8b4a8633bf6aa5bf8e5e7bc230
-# Adapters opted in for @ozzylabs/skills sync (per ADR-0018 / handbook#68).
 skills_adapters:
   - claude-code
   - codex-cli

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,20 +26,3 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
-
-<!-- begin: @ozzylabs/skills -->
-
-## Available Skills
-
-- `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
-- `commit-conventions` — Conventional Commits のメッセージ生成ルール（Type/Scope 判定表、フォーマット）。他スキルから参照される。
-- `drive` — Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。Issue 番号またはテキスト指示を受け取る。オプションでマージまで実行可能。
-- `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
-- `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
-- `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
-- `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
-- `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
-- `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
-- `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
-
-<!-- end: @ozzylabs/skills -->

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,8 @@
 [tools]
 # Runtime & package managers
 node = "24"
-pnpm = "10"
-uv = "0.11"
+"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
+uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
 
 # Linters & formatters
 biome = "2"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- begin: ozzy-labs/commons -->
 # Contributing
 
 This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
@@ -9,3 +10,4 @@ If you find a bug or have an idea for improvement, please open an issue.
 ## License
 
 By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).
+<!-- end: ozzy-labs/commons -->


### PR DESCRIPTION
Manual sync from ozzy-labs/commons. Picks up uv 0.11.8 pin (ozzy-labs/commons#98), npm:pnpm backend (ozzy-labs/commons#100), and pr-check dependabot/release-please skip (ozzy-labs/commons#97). Part of the 10-consumer rollout after starlight-theme pilot.