### PR TITLE
chore(deps): unpin uv to 0.11.10

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,7 +2,7 @@
 # Runtime & package managers
 node = "24"
 "npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
-uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
+uv = "0.11.10"
 
 # Linters & formatters
 biome = "2"


### PR DESCRIPTION
## Summary

- Unpin `uv` from `0.11.8` to `0.11.10` in `.mise.toml` and remove the workaround comment.
- The attestation verification failure tracked in `ozzy-labs/commons#98` (CLOSED) is resolved at `0.11.10`.

## Verification

- `mise install uv@0.11.10` — GitHub artifact attestations verified, checksum OK, extract OK
- `pnpm install` — OK
- `pnpm run build` — OK
- `pnpm run lint` — OK (pre-existing biome version info notice unrelated)
- `pnpm run test` — 51 tests passed across 3 packages

## Test plan

- [x] mise install passes attestation
- [x] pnpm install / build / lint / test
- [ ] CI green

Closes #29