### PR TITLE
chore(deps): sync commons to 8477956 (epic #96 final cleanup)

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -4,13 +4,15 @@
 # ozzy-labs/skills#80. 'pinned' is user-editable — add or remove paths
 # freely. 'commit' / 'skills_commit' / 'synced_at' should not be hand-
 # edited; they are rewritten by sync.sh / sync-skills.sh on each push.
-commit: 5fcde5666874736801b444dda33e02318f85dffb
-synced_at: 2026-06-07T03:40:47Z
+commit: 8477956d7b1da2521b9a3bdde7b498877ab53f97
+synced_at: 2026-06-07T06:37:53Z
 
 # Skills sync (opt-in). Add adapter ids to skills_adapters; skills_commit
 # is bumped by /sync-consumers --source=skills. The skills repo's main
 # HEAD SHA can be obtained via:
 #   gh api repos/ozzy-labs/skills/commits/main --jq .sha
+skills_commit: ""
+skills_adapters: []
 pinned:
   - CLAUDE.md
   - AGENTS.md


### PR DESCRIPTION
[ozzy-labs/skills#96](https://github.com/ozzy-labs/skills/issues/96) 完了後の final commit field bump + dist 反映。\

本セッションで commons に増えた commit (skill 配布廃止に伴う sync-consumers.sh / sync-skills.sh 削除等) を取り込む。dist 経由で consumer に伝播する実質的な変更は無いが、\.commons/sync.yaml の commit field が old SHA で behind だったため最新に bump する。

Refs: ozzy-labs/skills#96

🤖 Generated with [Claude Code](https://claude.com/claude-code)